### PR TITLE
Changed the scope to make it easier to extend this class

### DIFF
--- a/Model/QueueMessage.php
+++ b/Model/QueueMessage.php
@@ -15,13 +15,13 @@ class QueueMessage
      * @var array headers
      *
      */
-    private $headers;
+    protected $headers;
 
     /**
      * @var string data
      * The serialized event
      */
-    private $data;
+    protected $data;
 
     /**
      * @param null $data


### PR DESCRIPTION
There might be cases where you want to use a subclass of QueueMessage. This change will make it easier to have a meaningful purpose of that subclass. 
