### PR TITLE
changed to mq2php and made deferred bundle more configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,8 @@ class Configuration implements ConfigurationInterface
                                 ->integerNode('port')->defaultValue(5672)->end()
                                 ->scalarNode('user')->defaultValue('guest')->end()
                                 ->scalarNode('pass')->defaultValue('guest')->end()
+                                ->scalarNode('queue_name')->defaultValue('sf_deferred_events')->end()
+                                ->booleanNode('durable')->defaultFalse()->end()
 				->scalarNode('vhost')->defaultValue('/')->end()
                                 ->booleanNode('batch_publishing')->defaultValue(false)->end()
                             ->end()

--- a/Event/Queue/AmqpMessageQueue.php
+++ b/Event/Queue/AmqpMessageQueue.php
@@ -32,12 +32,6 @@ class AmqpMessageQueue implements MessageQueueInterface
     protected $queueChannel;
 
     /**
-     * @var string queueName
-     *
-     */
-    protected $queueName='sf_deferred_events';
-
-    /**
      * @var boolean batchPublishing
      */
     private $batchPublishing;
@@ -101,10 +95,10 @@ class AmqpMessageQueue implements MessageQueueInterface
 
         if ($this->batchPublishing) {
             //add to batch queue
-            $this->queueChannel->batch_basic_publish($queueMessage, '', $this->queueName);
+            $this->queueChannel->batch_basic_publish($queueMessage, '', $this->config['queue_name']);
         } else {
             //publish now
-            $this->queueChannel->basic_publish($queueMessage, '', $this->queueName);
+            $this->queueChannel->basic_publish($queueMessage, '', $this->config['queue_name']);
         }
     }
 
@@ -131,6 +125,6 @@ class AmqpMessageQueue implements MessageQueueInterface
         $this->queueChannel = $this->queueConnection->channel();
 
         //make sure we got a topic
-        $this->queueChannel->queue_declare($this->queueName, false, false, false, false);
+        $this->queueChannel->queue_declare($this->config['queue_name'], false, $this->config['durable'], false, false);
     }
 }


### PR DESCRIPTION
I wanted to use mq2php java part with this bundle, but mq2php creates the queue durable.
I also wanted to specify the name of the queue so this Pull Request made both options available via configuration.

The configuration has default values which fallback to the old values, so it does not cause backwards compatibility breaks.
